### PR TITLE
Configuring allow order sources from ENV

### DIFF
--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -95,13 +95,17 @@ class ShipmentsController < ApplicationController
       # Does the shipment have radios?
       has_radios = s.radio.any?
       # Is it from an order_source that we want in the main queue?
-      processable_order_source =  %w{squarespace kickstarter uncommon_goods other WBEZ warranty KUER LGA WFAE KERA KXT}.include?(s.order.order_source)
+      order_source_blacklisted = order_source_processing_blacklist.include?(s.order.order_source)
 
-      has_radios && processable_order_source
+      has_radios && !order_source_blacklisted
     end[0]
 
     # Return top of the queue
     api_response(@shipment)
+  end
+
+  def order_source_processing_blacklist
+    ENV['TPR_ORDER_SOURCES_PROCESSING_BLACKLIST'].nil? ? '' : ENV['TPR_ORDER_SOURCES_PROCESSING_BLACKLIST']
   end
 
   def shipment_label_created_count

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,7 +2,7 @@ class Order < ApplicationRecord
 	has_many :shipments
 
 	validates_presence_of :name
-	validates_inclusion_of :order_source, in: %w{squarespace kickstarter uncommon_goods other WBEZ warranty KUER LGA WFAE KERA KXT}
+	validates_inclusion_of :order_source, in: ENV['TPR_ORDER_SOURCES'].split(',')
 	validates_email_format_of :email, message: 'formated incorrectly', allow_nil: true
 	after_initialize :init
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ ENV['INVOICE_FROM_EMAIL_ADDRESS'] = 'billing@foo.com'
 ENV['EMAILS_TO_NOTIFY_OF_IMPORT'] = 'testnotify@foo.com'
 ENV['SQUARESPACE_API_KEY'] = 'test-key'
 ENV['SQUARESPACE_APP_NAME'] = 'test-app'
+ENV['TPR_ORDER_SOURCES'] = 'squarespace,kickstarter,uncommon_goods,other,WBEZ,warranty,KUER,LGA,WFAE,KERA,KXT'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
@pencerw This changes moves the configuration of the allowed order sources into the environment/config variables. There are two added here:

TPR_ORDER_SOURCES which is a comma separated list of the allowed order sources

TPR_ORDER_SOURCES_PROCESSING_BLACKLIST which is a comma separated list of any order sources you might want to exclude from the normal processing queue. It is currently empty. 