### PR TITLE
Send emails for Squarespace imports anytime there is a failed order

### DIFF
--- a/lib/tasks/orders/import_orders_from_squarespace.rake
+++ b/lib/tasks/orders/import_orders_from_squarespace.rake
@@ -64,6 +64,9 @@ namespace :orders do
         failed_orders << row
       end
     end
-    TaskHelper.notify_of_import('squarespace', failed_orders) if ENV['SEND_IMPORT_NOTIFICATION_EMAILS_SQUARESPACE'] == true
+    
+    if failed_orders.any? || ENV['SEND_IMPORT_NOTIFICATION_EMAILS_SQUARESPACE'] == true
+      TaskHelper.notify_of_import('squarespace', failed_orders)
+    end
   end
 end


### PR DESCRIPTION
Fixes #20 - we had removed `SEND_IMPORT_NOTIFICATION_EMAILS_SQUARESPACE` a while back so that there was not daily spam emails when the Squarespace import ran. Due to how the code was written, this also turned off emails when there were failures. This fixes that while preserving current functionality to get an email every import if desired. 