### PR TITLE
Set country code of radio the the user defined value by default, use order country otherwise

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -30,7 +30,7 @@ class OrdersController < ApplicationController
     frequency_hash = params['frequencies']
 
     if @order.save
-      make_shipments_for_internet_order(frequency_hash) unless frequency_hash.nil?
+      split_frequencies_into_shipments(frequency_hash) unless frequency_hash.nil?
       render json: @order, status: :created, location: @order
     else
       render json: @order.errors, status: :unprocessable_entity
@@ -53,50 +53,40 @@ class OrdersController < ApplicationController
 
   def make_queue_order_with_radios(working_order_params)
     @working_order_params = working_order_params
-    frequencies = working_order_params.delete(:frequencies)
+    frequency_hash = working_order_params.delete(:frequencies)
     @shipment_priority = working_order_params.delete(:shipment_priority)
-    @order = Order.new(@working_order_params)
-    @order.country = 'US' if @working_order_params[:country].nil?
+    @order = Order.new(working_order_params)
+    @order.conutry = 'US' if @working_order_params[:country].nil?
     unless @order.save
       Rails.logger.error("Order is invalid: #{@order.errors.messages}")
       raise OrderInvalid(@order.errors.messages)
     end
 
-    make_shipments_for_queue_order(frequencies)
+    split_frequencies_into_shipments(frequency_hash)
   end
 
   private
 
-    def make_shipments_for_queue_order(frequency_hash)
-      frequency_hash.each do |country_code, frequencies|
-        split_frequencies_into_shipments(country_code,frequencies)
-      end
-    end
-
-    def make_shipments_for_internet_order(frequency_hash)
+    def split_frequencies_into_shipments(frequency_hash)
       frequency_hash.each do |country_code,frequencies|
-        split_frequencies_into_shipments(country_code,frequencies) if !params['frequencies'].nil?
-      end
-    end
+        frequencies_by_shipment = []
 
-    def split_frequencies_into_shipments(country_code, frequencies)
-      frequencies_by_shipment = []
+        if frequencies.count > 3
+          num_radios_in_last_shipment = frequencies.count % 3
+          frequencies_by_shipment << frequencies.pop(num_radios_in_last_shipment)
 
-      if frequencies.count > 3
-        num_radios_in_last_shipment = frequencies.count % 3
-        frequencies_by_shipment << frequencies.pop(num_radios_in_last_shipment)
-
-        (frequencies.count / 3 ).times do
-          frequencies_by_shipment << frequencies.pop(3)
+          (frequencies.count / 3 ).times do
+            frequencies_by_shipment << frequencies.pop(3)
+          end
+        else
+          frequencies_by_shipment << frequencies
         end
-      else
-        frequencies_by_shipment << frequencies
-      end
 
-      shipment_priority = @shipment_priority.nil? ? params['shipment_priority'] : @shipment_priority
+        shipment_priority = @shipment_priority.nil? ? params['shipment_priority'] : @shipment_priority
 
-      frequencies_by_shipment.each do |frequencies|
-        ShipmentsController.new.create_shipment_from_order(@order, frequencies, shipment_priority)
+        frequencies_by_shipment.each do |frequencies|
+          ShipmentsController.new.create_shipment_from_order(@order, frequencies, shipment_priority)
+        end
       end
     end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -68,14 +68,11 @@ class OrdersController < ApplicationController
   private
 
     def split_frequencies_into_shipments(frequency_hash, shipment_priority)
-      frequency_hash.each do |country_code,frequencies|
-        # If there is more than 3 frequencies, break them up into sets of 3 due to packaging requirements
-        while frequencies.count > 3
-          ShipmentsController.new.create_shipment_from_order(@order, frequencies.pop(3), shipment_priority)
-        end
-        # Make any remaining radios in a shipment with less than 3 radios
-        ShipmentsController.new.create_shipment_from_order(@order, frequencies, shipment_priority)
+      radios = TaskHelper.convert_radio_map_to_array(frequency_hash)
+      while radios.count > 3
+        ShipmentsController.new.create_shipment_from_order(@order, radios.pop(3), shipment_priority)
       end
+      ShipmentsController.new.create_shipment_from_order(@order, radios, shipment_priority)
     end
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/helpers/task_helper.rb
+++ b/app/helpers/task_helper.rb
@@ -130,4 +130,18 @@ module TaskHelper
 
   class TPROrderAlreadyCreated < Exception
   end
+
+  def self.convert_radio_map_to_array(input)
+    output = []
+    input.each do |country, frequencies|
+      frequencies.each do |frequency|
+        output << {
+          'frequency': frequency,
+          'country': country
+        }
+      end
+    end
+
+    output
+  end
 end

--- a/app/helpers/task_helper.rb
+++ b/app/helpers/task_helper.rb
@@ -46,6 +46,23 @@ module TaskHelper
   end
 
   def create_order(order_params)
+    # Sample order params
+    # order_params = {
+    #   name: "John Doe",
+    #   order_source: "squarespace",
+    #   email: "john.doe@email.com",
+    #   street_address_1: shipping_address['address1'],
+    #   street_address_2: shipping_address['address2'],
+    #   city: shipping_address['city'],
+    #   state: shipping_address['state'],
+    #   postal_code: shipping_address['postalCode'],
+    #   country: shipping_address['countryCode'],
+    #   phone: shipping_address['phone'],
+    #   reference_number: "#{order['id']},#{order['orderNumber']}", # Squarespace order number
+    #   shipment_priority: 'economy',
+    #   frequencies: { radio_country_code => frequency_list.compact }
+    # }
+
     Rails.logger.info("Creating order with params: #{order_params}.")
     # Check if order has already been created
     if order_params[:reference_number].nil?

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe OrdersController, type: :controller do
 
       before(:each) do
         shipments_controller_double = object_double('shipments_controller', :create_shipment_from_order)
-        expect(ShipmentsController).to receive(:new).and_return(shipments_controller_double).exactly(4).times
-        expect(shipments_controller_double).to receive(:create_shipment_from_order).exactly(4).times
+        expect(ShipmentsController).to receive(:new).and_return(shipments_controller_double).exactly(3).times
+        expect(shipments_controller_double).to receive(:create_shipment_from_order).exactly(3).times
       end
       
       it "creates a shipment for each set of 3 radios, tracking numbers, and label data" do

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe ShipmentsController, type: :controller do
 
         let(:valid_shipping_attributes) do
           valid_attributes.delete('tracking_number')
-          valid_attributes['frequencies'] = ['98.1']
+          valid_attributes['frequencies'] = [{'frequency': '98.1', 'country': 'CA'}]
           valid_attributes
         end
 
@@ -254,8 +254,6 @@ RSpec.describe ShipmentsController, type: :controller do
             expect_shipment_object_params
             expect(Shipment.last.shipment_priority).to eq('priority')
           end
-
-          it 'creates radios with a country code'
         end
       end
     end

--- a/spec/controllers/shipments_controller_spec.rb
+++ b/spec/controllers/shipments_controller_spec.rb
@@ -254,6 +254,8 @@ RSpec.describe ShipmentsController, type: :controller do
             expect_shipment_object_params
             expect(Shipment.last.shipment_priority).to eq('priority')
           end
+
+          it 'creates radios with a country code'
         end
       end
     end

--- a/spec/helpers/task_helper_spec.rb
+++ b/spec/helpers/task_helper_spec.rb
@@ -157,5 +157,41 @@ RSpec.describe TaskHelper, type: :helper do
 
       expect{ helper.create_order(order_params) }.to raise_error(TaskHelper::TPROrderAlreadyCreated)
     end
-  end
+	end
+	
+	it 'converts a country and radio map into an arrya with country and radio pairs' do
+		input = {
+			'US': ['98.3', '79.5', '79.5', '98.3'],
+			'FR': ['79.5', '89.9']
+		}
+
+		output = [
+			{
+				'frequency': "98.3",
+				'country': 'US'
+			},
+			{
+				'frequency': "79.5",
+				'country': 'US'
+			},
+			{
+				'frequency': "79.5",
+				'country': 'US'
+			},
+			{
+				'frequency': "98.3",
+				'country': 'US'
+			},
+			{
+				'frequency': "79.5",
+				'country': 'FR'
+			},
+			{
+				'frequency': "89.9",
+				'country': 'FR'
+			}
+		]
+
+		output = TaskHelper.convert_radio_map_to_array(input)
+	end
 end

--- a/spec/tasks/orders/import_orders_from_squarespace_spec.rb
+++ b/spec/tasks/orders/import_orders_from_squarespace_spec.rb
@@ -8,10 +8,11 @@ describe "orders:import_orders_from_squarespace", type: :rake do
   end
 
   context 'from squarespace' do
+    let(:api_key) { ENV['SQUARESPACE_API_KEY'] }
+    let(:app_name) { ENV['SQUARESPACE_APP_NAME'] }
+    
     it 'import all pendings orders' do
         ENV['SEND_IMPORT_NOTIFICATION_EMAILS_SQUARESPACE'] = 'true'
-        api_key = ENV['SQUARESPACE_API_KEY']
-        app_name = ENV['SQUARESPACE_APP_NAME']
 
         squarespace_order_fixture = JSON.parse(load_fixture('spec/fixtures/squarespace_orders.json'))
         stub_client = instance_double(Squarespace::Client, :get_orders)
@@ -43,10 +44,19 @@ describe "orders:import_orders_from_squarespace", type: :rake do
                 shipment_priority: 'economy',
                 frequencies: { radio_country => ['82.7','82.7','82.7','82.7'] }
             }
-
             expect_any_instance_of(TaskHelper).to receive(:create_order).with(order_params)
+            # expect().to 
         end
         task.execute
+        # created_order = Order.find_by_email(test_order['customerEmail'])
+    end
+
+    skip 'sets the country code of the radio to the one the user requested' do 
+
+    end
+
+    skip 'sends an email when orders are formated incorrectly' do
+      expect(true).to eq true
     end
   end
 end

--- a/spec/tasks/orders/import_orders_from_squarespace_spec.rb
+++ b/spec/tasks/orders/import_orders_from_squarespace_spec.rb
@@ -50,13 +50,5 @@ describe "orders:import_orders_from_squarespace", type: :rake do
         task.execute
         # created_order = Order.find_by_email(test_order['customerEmail'])
     end
-
-    skip 'sets the country code of the radio to the one the user requested' do 
-
-    end
-
-    skip 'sends an email when orders are formated incorrectly' do
-      expect(true).to eq true
-    end
   end
 end


### PR DESCRIPTION
Fixes #31 

There was a case where we were setting the radio country code only by the Order country code and not by the radios. This switches the default behavior to be radio country code first and simplifies the core logic in how we break down shipments. 